### PR TITLE
fix bug with custom typecheckers

### DIFF
--- a/c/checks.c
+++ b/c/checks.c
@@ -241,7 +241,7 @@ static int checks( lua_State *L) {
                 r = lua_pcall( L, 1, 1, 0);       // val, checkers, result || msg
                 if( ! r && lua_toboolean( L, -1)) {// val, checkers, result==true
                     lua_pop( L, 3);                                          // -
-                    return 0;
+                    break;
                 } else {                               // val, checkers, errormsg
                     lua_pop( L, 1);                              // val, checkers
                 }


### PR DESCRIPTION
The custom typechecker code was early-exiting (not checking the remaining arguments) if a custom typechecking function returned true.

This fixes that.
